### PR TITLE
chore: Update action.yml with correct GitHub token description

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,8 +1,8 @@
 name: 'Generate CSV Report'
 description: 'Generates a CSV report from GitHub API data.'
 inputs:
-  token:
-    description: 'GitHub token for authentication.'
+  GITHUB_TOKEN:
+    description: 'GitHub token'
     required: true
   ent_name:
     description: 'Name of the enterprise.'


### PR DESCRIPTION
This pull request includes a change to the `action.yml` file. The change modifies the `token` input name to `GITHUB_TOKEN` and simplifies its description. This is likely to standardize the naming convention and make it more consistent with other parts of the codebase.